### PR TITLE
Fix bug with mouse_scroll events

### DIFF
--- a/src/main.lua
+++ b/src/main.lua
@@ -451,7 +451,7 @@ function love.mousepressed(x, y, button)
 				end
 				table.insert(Emulator.eventQueue, {"mouse_click", button, termMouseX, termMouseY})
 			elseif button == "wu" then -- Scroll up
-				table.insert(Emulator.eventQueue, {"mouse_scroll", -1, termMouseX, termMouseX})
+				table.insert(Emulator.eventQueue, {"mouse_scroll", -1, termMouseX, termMouseY})
 			elseif button == "wd" then -- Scroll down
 				table.insert(Emulator.eventQueue, {"mouse_scroll", 1, termMouseX, termMouseY})
 			end


### PR DESCRIPTION
Scrolling up would send the "mouse_scroll" event with the direction, x, and then x again.
