### PR TITLE
Add "open data folder" option

### DIFF
--- a/src/main.lua
+++ b/src/main.lua
@@ -183,7 +183,7 @@ keys = {
 	["capslock"] = 58,
 	["numlock"] = 69,
 	["scrolllock"] = 70,
-	
+
 	["f1"] = 59,
 	["f2"] = 60,
 	["f3"] = 61,
@@ -377,6 +377,15 @@ local function ui_aboutBox()
 	about.oText:SetText("CCLite by Gamax92. \n \n Credits: \n Sorroko: Original CCLite \n PixelToast: Fixes to CCLite \n #lua @ freenode: Code pieces \n #love @ OFTC: Support \n CC Devs: ComputerCraft \n Searge: Fernflower :P \n nikolairesokav: LoveFrames")
 end
 
+local function ui_openDataFolder()
+	if love.filesystem.isFused() then
+		love.system.openURL("file://"..love.filesystem.getAppdataDirectory().."/ccemu/data")
+	else
+		love.system.openURL("file://"..love.filesystem.getAppdataDirectory().."/love/ccemu/data")
+	end
+	--love.system.openURL("file://"..love.filesystem.getAppdataDirectory()..(love.filesystem.isFused() and "/ccemu/data") or "/love/ccemu/data")
+end
+
 function love.load()
 	if love.system.getOS() == "Android" then
 		love.keyboard.setTextInput(true)
@@ -387,13 +396,13 @@ function love.load()
 	end
 
 	require("libraries.loveframes")
-	
+
 	-- LoveFrames has no Menu Bar objects, emulate one.
 	menubar = loveframes.Create("panel")
 	menubar:SetSize(L2DScreenW, 25)
 	menubar.buttons = {}
 	local offset = 0
-	
+
 	local function addMenuBtn(data)
 		local menu = {}
 		menu.menu = loveframes.Create("menu")
@@ -417,11 +426,13 @@ function love.load()
 		table.insert(menubar.buttons, menu)
 		offset = offset + smallfont:getWidth(data.name) + 14
 	end
-	
+
 	addMenuBtn({
 		name = "File",
 		options = {
 			{"Edit Config",ui_editConfig},
+			{},
+			{"Open data folder", ui_openDataFolder},
 			{},
 			{"Exit",function() love.event.quit() end}
 		}
@@ -460,7 +471,7 @@ function love.load()
 	if not love.filesystem.exists("data/") then
 		love.filesystem.createDirectory("data/") -- Make the user data folder
 	end
-	
+
 	love.keyboard.setKeyRepeat(true)
 end
 
@@ -625,12 +636,12 @@ function love.run()
 	math.random() math.random()
 
 	love.event.pump()
-	
+
 	love.load(arg)
-	
+
 	-- We don't want the first frame's dt to include time taken by love.load.
     love.timer.step()
-	
+
 	local dt = 0
 
 	-- Main loop time.
@@ -672,17 +683,17 @@ function love.run()
 				_updateCheck.working = false
 			end
 		end
-		
+
 		-- Check HTTP requests
 		HttpRequest.checkRequests()
-		
+
 		if _conf.lockfps > 0 then next_time = next_time + min_dt end
-		
+
 		-- Call update and draw
 		for k,v in pairs(Emulator.computers) do
 			v:update(dt)
 		end
-		
+
 		-- Cleanup dead computers.
 		local deloff = 0
 		for i = 1,#Emulator.computers do
@@ -691,7 +702,7 @@ function love.run()
 				deloff = deloff + 1
 			end
 		end
-		
+
 		loveframes.update(dt)
 
 		-- Messages


### PR DESCRIPTION
Adds a button to access folder where computer data is saved to the "File" menu.

Fully tested on OSX, Windows and Ubuntu, works perfectly in fused and non-fused modes.
